### PR TITLE
fix(d3): 修复 d3 模块在 Linux 下的大小写问题

### DIFF
--- a/src/components/D3/d3.js
+++ b/src/components/D3/d3.js
@@ -1,2 +1,2 @@
 export * from "d3";
-export {default as tip} from "D3-tip";
+export {default as tip} from "d3-tip";


### PR DESCRIPTION
## 环境：

OS：CentOS，Linux x86_64
node: v12.13.1
DiscoveryUI: master 分支最新代码

## 问题现象：

Issue https://github.com/Nepxion/DiscoveryUI/issues/4 中有提到 Linux 下有大小写敏感问题。在修复尝试部署，仍然发现新增的 `src/components/D3/d3.js` 里面有大小写问题

## 期待行为

修复 `D3-tip` 大小写敏感引起的问题